### PR TITLE
feat: add --quiet and --errors-only options

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,24 @@ To save the readout of license information to a file:
 }
 ```
 
+## options
+
+```
+licensee -h
+Check npm package dependency license metadata against rules.
+
+Usage: licensee [options]
+
+Options:
+ --license EXPRESSION  Permit licenses matching SPDX expression.
+ --whitelist LIST      Permit comma-delimited name@range.
+ --errors-only         Only show NOT APPROVED packages.
+ --quiet               Quiet mode, only exit(0/1).
+ -h, --help            Print this screen to standard output.
+ -v, --version         Print version to standard output.
+```
+
+
 # JavaScript Module
 
 The package exports an asynchronous function of three arguments:

--- a/licensee
+++ b/licensee
@@ -13,6 +13,8 @@ var USAGE = [
   'Options:',
   '  --license EXPRESSION  Permit licenses matching SPDX expression.',
   '  --whitelist LIST      Permit comma-delimited name@range.',
+  '  --errors-only         Only show NOT APPROVED packages.',
+  '  --quiet               Quiet mode, only exit(0/1).',
   '  -h, --help            Print this screen to standard output.',
   '  -v, --version         Print version to standard output.'
 ].join('\n')
@@ -73,10 +75,32 @@ function checkDependencies () {
       } else {
         var haveIssue = false
         dependencies.forEach(function (dependency) {
-          if (!dependency.approved) {
+          var hideNonError = function () {
+            return options['--errors-only']
+          }
+          var isApproved = function () {
+            return dependency.approved
+          }
+          var isQuiet = function () {
+            return !!options['--quiet']
+          }
+          var printResult = function () {
+            process.stdout.write(formatResult(dependency) + '\n')
+          }
+
+          if (!isApproved()) {
             haveIssue = true
           }
-          process.stdout.write(formatResult(dependency) + '\n')
+
+          if (isQuiet()) {
+            return
+          }
+
+          if (!isApproved()) {
+            printResult()
+          } else if (!hideNonError()) {
+            printResult()
+          }
         })
         process.exit(haveIssue ? 1 : 0)
       }


### PR DESCRIPTION
--quiet produces no output and only exists with `exit(0)` on success
and `exit(1)` on any one failure.

--errors-only only shows licenses that have a `NOT APPROVED` status.

Closes #5.