### PR TITLE
Add --quiet option to suppress all output

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,16 @@ Consider adding `licensee` to your npm scripts:
 }
 ```
 
+To skip the readout of license information:
+
+```json
+{
+  "scripts": {
+    "posttest": "licensee --quiet"
+  }
+}
+```
+
 If you want a readout of dependency information, but don't want
 your continuous integration going red, you can ignore `licensee`'s
 exit code:

--- a/licensee
+++ b/licensee
@@ -14,6 +14,7 @@ var USAGE = [
   '  --license EXPRESSION  Permit licenses matching SPDX expression.',
   '  --whitelist LIST      Permit comma-delimited name@range.',
   '  --errors-only         Only show NOT APPROVED packages.',
+  '  --quiet               Quiet mode, only exit(0/1).',
   '  -h, --help            Print this screen to standard output.',
   '  -v, --version         Print version to standard output.'
 ].join('\n')
@@ -80,12 +81,19 @@ function checkDependencies () {
           var isApproved = function () {
             return dependency.approved
           }
+          var isQuiet = function () {
+            return !!options['--quiet']
+          }
           var printResult = function () {
             process.stdout.write(formatResult(dependency) + '\n')
           }
 
           if (!isApproved()) {
             haveIssue = true
+          }
+
+          if (isQuiet()) {
+            return
           }
 
           if (!isApproved()) {


### PR DESCRIPTION
cc @janl, who wrote the code.  I split this feature-add out of #8, which also had `--errors-only`, out in 4.1.0.

Absolutely no doubt that this is a natural and potentially common use case. It's also fairly simple to implement.  It's really easy to do in the shell, too: `licensee &>/dev/null`.

My only concern is keeping this thing as small as possible.  An option like `--quiet` probably deserves that concern less than anything else the shell could do.  And I'm sure it's possible to do `--errors-only` with `grep` and context lines.  Then again, I could see an argument that, technically, as a matter of efficiency, a `--quiet` run ought not compile a big list of results, and just short-circuit as soon as it sees an error, &c. &c. &c.

Maybe I'm just paranoid.  Maybe I overestimate interest in shell and its mysteries.  I might just be wrong.  But it gives me the heebie-jeebies.  I'd hate to see all kinds of flags and options for formatting add up over time.  The madness of something like `git log` is clearly contagious.