### PR TITLE
Add --production option

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,12 @@
 module.exports = licensee
 
 var licenseSatisfies = require('spdx-satisfies')
+var parseJSON = require('json-parse-errback')
 var readPackageTree = require('read-package-tree')
+var runParallel = require('run-parallel')
 var satisfies = require('semver').satisfies
+var simpleConcat = require('simple-concat')
+var spawn = require('child_process').spawn
 var validSPDX = require('spdx-expression-validate')
 
 function licensee (configuration, path, callback) {
@@ -11,12 +15,102 @@ function licensee (configuration, path, callback) {
   } else if (!validSPDX(configuration.license)) {
     callback(new Error('Invalid license expression'))
   } else {
-    // Read the package tree from `node_modules`.
-    readPackageTree(path, function (error, tree) {
-      if (error) callback(error)
-      else callback(null, findIssues(configuration, tree, []))
+    if (configuration.productionOnly) {
+      // In order to ignore devDependencies, we need to read:
+      //
+      // 1. the dependencies-only dependency graph, from
+      //    `npm ls --json --production`
+      //
+      // 2. the structure of `node_modules` and `package.json`
+      //    files within it, with read-package-tree.
+      //
+      // `npm ls` calls read-package-tree internally, but does
+      // lots of npm-specific post-processing to produce the
+      // dependency tree.  Calling read-package-tree twice, at
+      // the same time, is far from efficient.  But it works,
+      // and doing so helps keep this package small.
+      runParallel({
+        dependencies: readDependencyList,
+        packages: readFilesystemTree
+      }, function (error, trees) {
+        if (error) callback(error)
+        else withTrees(trees.packages, trees.dependencies)
+      })
+    } else {
+      // If we are analyzing _all_ installed dependencies,
+      // and don't care whether they're devDependencies
+      // or not, just read `node_modules`.  We don't need
+      // the dependency graph.
+      readFilesystemTree(function (error, packages) {
+        if (error) callback(error)
+        else withTrees(packages, false)
+      })
+    }
+  }
+
+  function withTrees (packages, dependencies) {
+    callback(null, findIssues(
+      configuration, packages, dependencies, []
+    ))
+  }
+
+  function readDependencyList (done) {
+    var child = spawn(
+      'npm', ['ls', '--production', '--json'], {cwd: path}
+    )
+    var outputError
+    var json
+    simpleConcat(child.stdout, function (error, buffer) {
+      if (error) outputError = error
+      else json = buffer
+    })
+    child.once('close', function (code) {
+      if (code !== 0) {
+        done(new Error('npm exited with status ' + code))
+      } else if (outputError) {
+        done(outputError)
+      } else {
+        parseJSON(json, function (error, graph) {
+          if (error) return done(error)
+          if (!graph.hasOwnProperty('dependencies')) {
+            done(new Error('cannot interpret npm ls --json output'))
+          } else {
+            var flattened = {}
+            flattenDependencyTree(graph.dependencies, flattened)
+            done(null, flattened)
+          }
+        })
+      }
     })
   }
+
+  function readFilesystemTree (done) {
+    readPackageTree(path, function (error, tree) {
+      if (error) return done(error)
+      done(null, tree.children)
+    })
+  }
+}
+
+var KEY_PREFIX = '.'
+
+function flattenDependencyTree (graph, object) {
+  Object.keys(graph).forEach(function (name) {
+    var node = graph[name]
+    var version = node.version
+    var key = KEY_PREFIX + name
+    if (
+      object.hasOwnProperty(key) &&
+      object[key].indexOf(version) === -1
+    ) {
+      object[key].push(version)
+    } else {
+      object[key] = [version]
+    }
+    if (node.hasOwnProperty('dependencies')) {
+      flattenDependencyTree(node.dependencies, object)
+    }
+  })
 }
 
 function validConfiguration (configuration) {
@@ -44,19 +138,32 @@ function isString (argument) {
   return typeof argument === 'string'
 }
 
-function findIssues (configuration, tree, results) {
-  var dependencies = tree.children
-  // If there are dependencies, check license metadata.
-  if (typeof dependencies === 'object') {
-    dependencies.forEach(function (tree) {
-      results.push(resultForPackage(configuration, tree))
-      findIssues(configuration, tree, results)
-      if (tree.hasOwnProperty('children')) {
-        findIssues(configuration, tree.children, results)
+function findIssues (configuration, children, dependencies, results) {
+  if (Array.isArray(children)) {
+    children.forEach(function (child) {
+      if (
+        !configuration.productionOnly ||
+        appearsIn(child, dependencies)
+      ) {
+        results.push(resultForPackage(configuration, child))
+        findIssues(configuration, child, dependencies, results)
+      }
+      if (child.children) {
+        findIssues(configuration, child.children, dependencies, results)
       }
     })
     return results
   } else return results
+}
+
+function appearsIn (installed, dependencies) {
+  var name = installed.package.name
+  var key = KEY_PREFIX + name
+  var version = installed.package.version
+  return (
+    dependencies.hasOwnProperty(key) &&
+    dependencies[key].indexOf(version) !== -1
+  )
 }
 
 function resultForPackage (configuration, tree) {

--- a/licensee
+++ b/licensee
@@ -17,6 +17,7 @@ var USAGE = [
   '  --license EXPRESSION  Permit licenses matching SPDX expression.',
   '  --whitelist LIST      Permit comma-delimited name@range.',
   '  --errors-only         Only show NOT APPROVED packages.',
+  '  --production          Do not check devDependencies.',
   '  --ndjson              Print newline-delimited JSON objects.',
   '  --quiet               Quiet mode, only exit(0/1).',
   '  -h, --help            Print this screen to standard output.',
@@ -99,6 +100,7 @@ if (options['--init']) {
 }
 
 function checkDependencies () {
+  configuration.productionOnly = options['--production']
   require('./')(configuration, cwd, function (error, dependencies) {
     if (error) {
       die(error.message + '\n')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1373,6 +1373,11 @@
       "dev": true,
       "optional": true
     },
+    "json-parse-errback": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/json-parse-errback/-/json-parse-errback-2.0.1.tgz",
+      "integrity": "sha1-x6nCvjqFWzQvgqv8ibyFk1tYhPo="
+    },
     "json-parse-helpfulerror": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
@@ -3581,8 +3586,7 @@
     "run-parallel": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.6.tgz",
-      "integrity": "sha1-KQA8miFj4B4tLfyQV18sbB1hoDk=",
-      "dev": true
+      "integrity": "sha1-KQA8miFj4B4tLfyQV18sbB1hoDk="
     },
     "rx-lite": {
       "version": "3.1.2",
@@ -3617,6 +3621,11 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
+    },
+    "simple-concat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
+      "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
     },
     "slice-ansi": {
       "version": "0.0.4",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,11 @@
   "dependencies": {
     "docopt": "^0.6.2",
     "fs-access": "^1.0.0",
+    "json-parse-errback": "^2.0.1",
     "read-package-tree": "^5.1.2",
+    "run-parallel": "^1.1.6",
     "semver": "^5.1.0",
+    "simple-concat": "^1.0.0",
     "spdx-expression-validate": "^1.0.1",
     "spdx-satisfies": "^0.1.3"
   },

--- a/tests/production-only/.licensee.json
+++ b/tests/production-only/.licensee.json
@@ -1,0 +1,4 @@
+{
+  "license": "MIT",
+  "whitelist": {}
+}

--- a/tests/production-only/package.json
+++ b/tests/production-only/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "mit-not-allowed",
+  "dependencies": {
+    "mit-licensed": "1.0.0"
+  },
+  "devDependencies": {
+    "apache-2.0-licensed": "1.0.0"
+  },
+  "private": true
+}

--- a/tests/production-only/test.js
+++ b/tests/production-only/test.js
@@ -1,0 +1,10 @@
+var tap = require('tap')
+
+var results = require('../run')(['--production'], __dirname)
+
+tap.equal(results.status, 0)
+
+tap.equal(
+  results.stdout.indexOf('NOT APPROVED') === -1,
+  true
+)


### PR DESCRIPTION
@ljharb, here's your PR, sir.

As discussed in #18, shelling out to npm CLI feels like the least-bad bad way to go about this. It's slow. It's redundant. We're running read-package-tree on the same tree, at the same time. But `npm ls --json`'s output seems pretty stable, and I think this flag will be popular.

My implementation makes just one moderately interesting decision, which is to flatten the dependency graph from `npm ls --json`, so checking whether a package on disk is a package in the dependency graph comes easy.