### PR TITLE
spdx-expression-validate@2.0.0 (close #33)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "run-parallel": "^1.1.9",
     "semver": "^5.6.0",
     "simple-concat": "^1.0.0",
-    "spdx-expression-validate": "^1.0.1",
+    "spdx-expression-validate": "^2.0.0",
     "spdx-satisfies": "^4.0.0"
   },
   "bin": "./licensee",


### PR DESCRIPTION
@ljharb, looks like the package used to validate SPDX IDs here had fallen behind.

The package at the bottom that actually contains the list of IDs is `spdx-license-ids`.