### PR TITLE
Fix testing on Node.js 4 and 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 ---
 language: "node_js"
-node_js: [ "6", "7", "8", "9", "10", "node" ]
+node_js: [ "4", "5", "6", "7", "8", "9", "10", "node" ]
 script:
   - "npm run test"
   - "npm run style"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "spawn-sync": "^2.0.0",
     "standard": "^12.0.1",
-    "tap": "^12.1.0"
+    "tap": "^11.0.0"
   },
   "license": "Apache-2.0",
   "repository": "jslicense/licensee.js",


### PR DESCRIPTION
Turns out tap@12 busts Node 4 and 5 compatibility. Holding at tap@11 so we can keep supporting those old Node versions.