### PR TITLE
Automatically correct metadata

### DIFF
--- a/.licensee.json
+++ b/.licensee.json
@@ -1,4 +1,14 @@
 {
-  "license": "(MIT OR Apache-2.0 OR BSD-2-Clause OR BSD-3-Clause OR ISC OR CC-BY-3.0)",
-  "whitelist": {}
+  "license": "(MIT OR Apache-2.0 OR BSD-2-Clause OR BSD-3-Clause OR ISC OR CC-BY-3.0 OR Unlicense OR CC0-1.0)",
+  "whitelist": {
+    "deep-is": "0.1.3",
+    "diff": "1.4.0",
+    "doctrine": "1.5.0",
+    "esutils": "2.0.2",
+    "json-schema": "0.2.3",
+    "wordwrap": "0.0.2",
+    "longest": "1.0.1",
+    "repeat-element": "1.1.2"
+  },
+  "corrections": true
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,5 @@ node_js: [ "4", "5", "6", "7", "8", "9", "10", "node" ]
 script:
   - "npm run test"
   - "npm run style"
+  - "npm run licenses"
 sudo: false

--- a/README.md
+++ b/README.md
@@ -44,9 +44,13 @@ described in `whitelist` will not cause an error.
 The `corrections` flag toggles community corrections to npm package
 license metadata.  When enabled, `licensee` will check `license` and
 `whitelist` against `license` values from [npm-license-corrections]
-when available.
+when available, and also use [correct-license-metadata] to try to
+correct old-style `licenses` arrays and other unambiguous, but
+invalid, metadata.
 
 [npm-license-corrections]: https://www.npmjs.com/package/npm-license-corrections
+
+[correct-license-metadata]: https://www.npmjs.com/package/correct-license-metadata
 
 The optional `ignore` array instructs `licensee` to approve packages
 without considering their `license` metadata.  Ignore rules can take

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 module.exports = licensee
 
+var correctLicenseMetadata = require('correct-license-metadata')
 var licenseSatisfies = require('spdx-satisfies')
 var npmLicenseCorrections = require('npm-license-corrections')
 var parseJSON = require('json-parse-errback')
@@ -200,8 +201,9 @@ function resultForPackage (configuration, tree) {
     parent: tree.parent,
     path: tree.path
   }
-  // Find and apply any license metadata correction.
-  var correction = (
+
+  // Find and apply any manual license metadata correction.
+  var manualCorrection = (
     configuration.corrections &&
     npmLicenseCorrections.find(function (correction) {
       return (
@@ -210,9 +212,19 @@ function resultForPackage (configuration, tree) {
       )
     })
   )
-  if (correction) {
-    result.license = correction.license
-    result.corrected = true
+  if (manualCorrection) {
+    result.license = manualCorrection.license
+    result.corrected = 'manual'
+  }
+
+  // Find and apply any automatic license metadata correction.
+  var automaticCorrection = (
+    configuration.corrections &&
+    correctLicenseMetadata(tree.package)
+  )
+  if (automaticCorrection) {
+    result.license = automaticCorrection
+    result.corrected = 'automatic'
   }
 
   // Check if ignored.

--- a/licensee
+++ b/licensee
@@ -156,6 +156,15 @@ function toText (result) {
       : '  NOT APPROVED\n'
     ) +
     '  Terms: ' + displayLicense(result.license) + '\n' +
+    (
+        result.corrected
+        ? (
+          result.corrected === 'automatic'
+            ? '  Corrected: correct-license-metadata\n'
+            : '  Corrected: npm-license-corrections\n'
+        )
+        : ''
+    ) +
     '  Repository: ' + formatRepo(result.repository) + '\n' +
     '  Homepage: ' + formatRepo(result.homepage) + '\n' +
     '  Author: ' + formatPerson(result.author) + '\n' +

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "license": "Apache-2.0",
   "repository": "jslicense/licensee.js",
   "scripts": {
+    "licenses": "./licensee --errors-only",
     "style": "standard index.js",
     "test": "tap tests/**/test.js"
   }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "Jakob Krigovsky <jakob@krigovsky.com>"
   ],
   "dependencies": {
+    "correct-license-metadata": "^1.0.1",
     "docopt": "^0.6.2",
     "fs-access": "^2.0.0",
     "json-parse-errback": "^2.0.1",

--- a/tests/licenses-array-with-corrections/.licensee.json
+++ b/tests/licenses-array-with-corrections/.licensee.json
@@ -1,0 +1,4 @@
+{
+  "license": "MIT",
+  "whitelist": {}
+}

--- a/tests/licenses-array-with-corrections/node_modules/has-licenses-array/package.json
+++ b/tests/licenses-array-with-corrections/node_modules/has-licenses-array/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "has-licenses-array",
+  "version": "0.0.0",
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "https://opensource.org/licenses/MIT"
+    }
+  ]
+}

--- a/tests/licenses-array-with-corrections/package.json
+++ b/tests/licenses-array-with-corrections/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "dependencies": {
+    "has-licenses-array": "0.0.0"
+  }
+}

--- a/tests/licenses-array-with-corrections/test.js
+++ b/tests/licenses-array-with-corrections/test.js
@@ -1,0 +1,5 @@
+var tap = require('tap')
+
+var results = require('../run')(['--corrections'], __dirname)
+
+tap.equal(results.status, 0)


### PR DESCRIPTION
This pull request adds additional functionality when corrections are enabled. Instead of relying only on the manually vetted list in [`npm-license-corrections`](https://www.npmjs.com/package/npm-license-corrections), `licensee` also applies [`correct-license-metadata`](https://www.npmjs.com/package/correct-license-metadata), which in turn applies some reliable rules to correct old-style `licenses` arrays and other common, but unambiguous, invalid metadata.

`correct-license-metadata` is very conservative. I don't foresee much additional risk in using its automatic corrections.