### PR TITLE
Support rule generation from Blue Oak Council list

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,18 @@ according to [spdx-satisfies][satisfies] will not cause an error.
 [parse]: https://www.npmjs.com/package/spdx-expression-parse
 [satisfies]: https://www.npmjs.com/package/spdx-satisfies
 
+Instead of a `license` property, you can specify a minimum
+Blue Oak Council [license rating]---lead, bronze, silver, or
+gold---from which `licensee` will generate a rule:
+
+[license rating]: https://blueoakcouncil.org/license
+
+```json
+{
+  "blueOak": "bronze"
+}
+```
+
 The `whitelist` is a map from package name to a [node-semver][semver]
 Semantic Versioning range. Packages whose license metadata don't match
 the SPDX license expression in `license` but have a name and version

--- a/licensee
+++ b/licensee
@@ -10,12 +10,13 @@ var USAGE = [
   '',
   'Usage:',
   '  licensee [options]',
-  '  licensee --license=EXPRESSION [--whitelist=LIST] [options]',
+  '  licensee (--license=EXPRESSION | --blueoak=RATING) [--whitelist=LIST] [options]',
   '',
   'Options:',
   '  --init                Create a .licensee.json file.',
   '  --corrections         Use crowdsourced license metadata corrections.',
   '  --license EXPRESSION  Permit licenses matching SPDX expression.',
+  '  --blueoak=RATING      Permit licenses by Blue Oak Council rating.',
   '  --whitelist LIST      Permit comma-delimited name@range.',
   '  --errors-only         Only show NOT APPROVED packages.',
   '  --production          Do not check devDependencies.',
@@ -65,9 +66,10 @@ if (options['--init']) {
       }
     }
   )
-} else if (options['--license'] || options['--whitelist']) {
+} else if (options['--license'] || options['--blueoak'] || options['--whitelist']) {
   configuration = {
     license: options['--license'] || undefined,
+    blueOak: options['--blueoak'] || undefined,
     whitelist: options['--whitelist']
       ? parseWhitelist(options['--whitelist'])
       : {},

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "Jakob Krigovsky <jakob@krigovsky.com>"
   ],
   "dependencies": {
+    "@blueoak/list": "^1.0.2",
     "correct-license-metadata": "^1.0.1",
     "docopt": "^0.6.2",
     "fs-access": "^2.0.0",

--- a/tests/blue-oak-fail/.licensee.json
+++ b/tests/blue-oak-fail/.licensee.json
@@ -1,0 +1,4 @@
+{
+  "blueOak": "bronze",
+  "whitelist": {}
+}

--- a/tests/blue-oak-fail/package.json
+++ b/tests/blue-oak-fail/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "blue-oak-fail",
+  "dependencies": {
+    "gpl-2.0-licensed": "1.0.0"
+  },
+  "private": true
+}

--- a/tests/blue-oak-fail/test.js
+++ b/tests/blue-oak-fail/test.js
@@ -1,0 +1,10 @@
+var tap = require('tap')
+
+var results = require('../run')([], __dirname)
+
+tap.equal(results.status, 1)
+
+tap.equal(
+  results.stdout.indexOf('NOT APPROVED') > -1,
+  true
+)

--- a/tests/blue-oak-flag/package.json
+++ b/tests/blue-oak-flag/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "mit-not-allowed",
+  "dependencies": {
+    "mit-licensed": "1.0.0"
+  },
+  "private": true
+}

--- a/tests/blue-oak-flag/test.js
+++ b/tests/blue-oak-flag/test.js
@@ -1,0 +1,5 @@
+var tap = require('tap')
+
+var results = require('../run')(['--blueoak=bronze'], __dirname)
+
+tap.equal(results.status, 0)

--- a/tests/blue-oak-pass/.licensee.json
+++ b/tests/blue-oak-pass/.licensee.json
@@ -1,0 +1,4 @@
+{
+  "blueOak": "bronze",
+  "whitelist": {}
+}

--- a/tests/blue-oak-pass/package.json
+++ b/tests/blue-oak-pass/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "mit-not-allowed",
+  "dependencies": {
+    "mit-licensed": "1.0.0"
+  },
+  "private": true
+}

--- a/tests/blue-oak-pass/test.js
+++ b/tests/blue-oak-pass/test.js
@@ -1,0 +1,5 @@
+var tap = require('tap')
+
+var results = require('../run')([ ], __dirname)
+
+tap.equal(results.status, 0)


### PR DESCRIPTION
This PR adds a `--blueoak RATING` flag and `blueOak` configuration property for `.licensee.json` to automatically generate a license rule based on [Blue Oak Council's permissive license list and ratings](https://blueoakcouncil.org/list).

In a nutshell, this addresses a long-running feature request for a "permissive-only" option.