### PR TITLE
Version 7

### DIFF
--- a/.licensee.json
+++ b/.licensee.json
@@ -1,6 +1,11 @@
 {
-  "license": "(MIT OR Apache-2.0 OR BSD-2-Clause OR BSD-3-Clause OR ISC OR CC-BY-3.0 OR Unlicense OR CC0-1.0)",
-  "whitelist": {
+  "licenses": {
+    "spdx": [
+      "CC-BY-3.0"
+    ],
+    "blueOak": "bronze"
+  },
+  "packages": {
     "deep-is": "0.1.3",
     "diff": "1.4.0",
     "doctrine": "1.5.0",

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 ---
 language: "node_js"
-node_js: [ "4", "5", "6", "7", "8", "9", "10", "node" ]
+node_js: [ "4", "5", "6", "7", "8", "9", "10", "11", "node" ]
 script:
   - "npm run test"
   - "npm run style"

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ rating]---lead, bronze, silver, or gold---like so:
 }
 ```
 
-You can also whitelist all [OSI]-approved licenses with `osi`:
+You can also whitelist all [OSI]-approved licenses:
 
 [osi]: https://opensource.org
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,15 @@ file at the root of your package, like so:
 
 ```json
 {
-  "license": "(MIT OR BSD-2-Clause OR BSD-3-Clause OR Apache-2.0)",
-  "whitelist": {
+  "licenses": {
+    "spdx": [
+      "MIT",
+      "BSD-2-Clause",
+      "BSD-3-Clause",
+      "Apache-2.0"
+    ]
+  },
+  "packages": {
     "optimist": "<=0.6.1"
   },
   "corrections": false,
@@ -25,17 +32,19 @@ file at the root of your package, like so:
 }
 ```
 
-The `license` property is an SPDX license expression that
-[spdx-expression-parse][parse] can parse. Any package with [standard
-license metadata][metadata] that satisfies the SPDX license expression
-according to [spdx-satisfies][satisfies] will not cause an error.
+The `licenses` object adds licenses to a whitelist.
+Any package with [standard license metadata][metadata]
+that satisfies that whitelist according to
+[spdx-whitelisted][whitelisted] will not cause an error.
 
 [parse]: https://www.npmjs.com/package/spdx-expression-parse
-[satisfies]: https://www.npmjs.com/package/spdx-satisfies
+[whitelisted]: https://www.npmjs.com/package/spdx-whitelisted
 
-Instead of a `license` property, you can specify a minimum
-Blue Oak Council [license rating]---lead, bronze, silver, or
-gold---from which `licensee` will generate a rule:
+Instead of whitelisting each license by SPDX identifier,
+you can whitelist categories of licenses.
+
+You can specify a minimum Blue Oak Council [license
+rating]---lead, bronze, silver, or gold---like so:
 
 [license rating]: https://blueoakcouncil.org/license
 
@@ -45,18 +54,29 @@ gold---from which `licensee` will generate a rule:
 }
 ```
 
-The `whitelist` is a map from package name to a [node-semver][semver]
-Semantic Versioning range. Packages whose license metadata don't match
-the SPDX license expression in `license` but have a name and version
-described in `whitelist` will not cause an error.
+You can also whitelist all [OSI]-approved licenses with `osi`:
+
+[osi]: https://opensource.org
+
+```json
+{
+  "osi": true
+}
+```
+
+The `packages` property is a map from package name to a
+[node-semver][semver] Semantic Versioning range.  Packages whose
+license metadata don't match the SPDX license expression in
+`licenses` but have a name and version described in `packages`
+will not cause an error.
 
 [metadata]: https://docs.npmjs.com/files/package.json#license
 [semver]: https://www.npmjs.com/package/semver
 
-The `corrections` flag toggles community corrections to npm package
-license metadata.  When enabled, `licensee` will check `license` and
-`whitelist` against `license` values from [npm-license-corrections]
-when available, and also use [correct-license-metadata] to try to
+The `corrections` flag toggles community corrections to npm
+package license metadata.  When enabled, `licensee` will check
+against `license` values from [npm-license-corrections] when
+available, and also use [correct-license-metadata] to try to
 correct old-style `licenses` arrays and other unambiguous, but
 invalid, metadata.
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ rating]---lead, bronze, silver, or gold---like so:
 
 ```json
 {
-  "blueOak": "bronze"
+  "licenses": {
+    "blueOak": "bronze"
+  }
 }
 ```
 
@@ -60,7 +62,21 @@ You can also whitelist all [OSI]-approved licenses:
 
 ```json
 {
-  "osi": true
+  "licenses": {
+    "osi": true
+  }
+}
+```
+
+All of these can be combined:
+
+```json
+{
+  "licenses": {
+    "spdx": ["CC-BY-4.0"],
+    "blueOak": "gold",
+    "osi": true
+  }
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -196,6 +196,9 @@ function resultForPackage (configuration, tree) {
     .reduce(function (whitelist, element) {
       try {
         var parsed = parse(element)
+        if (parsed.hasOwnProperty('conjunction')) {
+          throw new Error('Cannot match against "' + JSON.stringify(element) + '".')
+        }
         return whitelist.concat(parsed)
       } catch (e) {
         return whitelist

--- a/index.js
+++ b/index.js
@@ -369,6 +369,6 @@ function compileLicenseWhitelist (configuration) {
 
 function pushMissing (source, sink) {
   source.forEach(function (element) {
-    if (!sink.includes(element)) sink.push(element)
+    if (sink.indexOf(element) === -1) sink.push(element)
   })
 }

--- a/licensee
+++ b/licensee
@@ -10,20 +10,20 @@ var USAGE = [
   '',
   'Usage:',
   '  licensee [options]',
-  '  licensee (--license=EXPRESSION | --blueoak=RATING) [--whitelist=LIST] [options]',
   '',
   'Options:',
-  '  --init                Create a .licensee.json file.',
-  '  --corrections         Use crowdsourced license metadata corrections.',
-  '  --license EXPRESSION  Permit licenses matching SPDX expression.',
-  '  --blueoak=RATING      Permit licenses by Blue Oak Council rating.',
-  '  --whitelist LIST      Permit comma-delimited name@range.',
-  '  --errors-only         Only show NOT APPROVED packages.',
-  '  --production          Do not check devDependencies.',
-  '  --ndjson              Print newline-delimited JSON objects.',
-  '  --quiet               Quiet mode, only exit(0/1).',
-  '  -h, --help            Print this screen to standard output.',
-  '  -v, --version         Print version to standard output.'
+  '  --init                  Create a .licensee.json file.',
+  '  --corrections           Use crowdsourced license metadata corrections.',
+  '  --blueoak=RATING        Permit licenses by Blue Oak Council rating.',
+  '  --licenses IDENTIFIERS  Permit licenses matching comma-separated list of SPDX identifiers.',
+  '  --osi                   Permit licenses approved by the Open Source Initiative.',
+  '  --packages LIST         Permit comma-delimited name@range.',
+  '  --errors-only           Only show NOT APPROVED packages.',
+  '  --production            Do not check devDependencies.',
+  '  --ndjson                Print newline-delimited JSON objects.',
+  '  --quiet                 Quiet mode, only exit(0/1).',
+  '  -h, --help              Print this screen to standard output.',
+  '  -v, --version           Print version to standard output.'
 ].join('\n')
 
 var options = docopt.docopt(USAGE, {
@@ -38,13 +38,14 @@ if (options['--init']) {
   fs.writeFile(
     configurationPath,
     JSON.stringify({
-      license: (
-        options['--expression'] ||
-        '(MIT OR BSD-2-Clause OR BSD-3-Clause OR Apache-2.0)'
-      ),
-      whitelist: (
-        options['--whitelist']
-          ? parseWhitelist(options['--whitelist'])
+      licenses: {
+        spdx: [
+          'MIT', 'BSD-2-Clause', 'BSD-3-Clause', 'Apache-2.0'
+        ]
+      },
+      packages: (
+        options['--packages']
+          ? parsePackageWhitelist(options['--packages'])
           : {optimist: '<=0.6.1'}
       ),
       corrections: false
@@ -66,12 +67,20 @@ if (options['--init']) {
       }
     }
   )
-} else if (options['--license'] || options['--blueoak'] || options['--whitelist']) {
+} else if (
+  options['--spdx'] ||
+  options['--osi'] ||
+  options['--blueoak'] ||
+  options['--packages']
+) {
   configuration = {
-    license: options['--license'] || undefined,
-    blueOak: options['--blueoak'] || undefined,
-    whitelist: options['--whitelist']
-      ? parseWhitelist(options['--whitelist'])
+    licenses: {
+      spdx: options['--spdx'] || undefined,
+      blueOak: options['--blueoak'] || undefined,
+      osi: options['--osi'] || undefined
+    },
+    packages: options['--packages']
+      ? parsePackageWhitelist(options['--packages'])
       : {},
     corrections: options['--corrections']
   }
@@ -83,7 +92,7 @@ if (options['--init']) {
         [
           'Cannot read ' + configurationPath + '.',
           'Create ' + configurationPath + ' with licensee --init',
-          'or configure with --license and --whitelist.',
+          'or configure with --spdx, --blueoak, --osi, and --packages.',
           'See licensee --help for more information.'
         ].join('\n')
       )
@@ -153,7 +162,7 @@ function toText (result) {
       result.approved
       ? (
         '  Approved by ' +
-        (result.whitelisted ? 'whitelist' : 'rule') + '\n'
+        (result.license ? 'license' : 'package') + '\n'
       )
       : '  NOT APPROVED\n'
     ) +
@@ -243,7 +252,7 @@ function die (message) {
   process.exit(1)
 }
 
-function parseWhitelist (string) {
+function parsePackageWhitelist (string) {
   return string
     .split(',')
     .map(function (string) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@blueoak/list": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@blueoak/list/-/list-1.0.2.tgz",
+      "integrity": "sha512-KyqT0kkdxgbGys9mvo/1Mgdt/LGvUFPCZIK9pWPIfOM2mYzMDd/eVYy4sMP1YqvVI129k0alxRyM53H2MAs/Nw=="
+    },
     "acorn": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
@@ -4673,18 +4678,22 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
       "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g=="
     },
+    "spdx-osi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-osi/-/spdx-osi-3.0.0.tgz",
+      "integrity": "sha512-7DZMaD/rNHWGf82qWOazBsLXQsaLsoJb9RRjhEUQr5o86kw3A1ErGzSdvaXl+KalZyKkkU5T2a5NjCCutAKQSw=="
+    },
     "spdx-ranges": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/spdx-ranges/-/spdx-ranges-2.1.0.tgz",
       "integrity": "sha512-OOWghvosfmECc9edy/A9j7GabERmn8bJWHc0J1knVytQtO5Rw7VfxK6CDqmivJhfMJqWhWWUfffNNMPYvyvyQA=="
     },
-    "spdx-satisfies": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-satisfies/-/spdx-satisfies-5.0.0.tgz",
-      "integrity": "sha512-/hGhwh20BeGmkA+P/lm06RvXD94JduwNxtx/oX3B5ClPt1/u/m5MCaDNo1tV3Y9laLkQr/NRde63b9lLMhlNfw==",
+    "spdx-whitelisted": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-whitelisted/-/spdx-whitelisted-1.0.0.tgz",
+      "integrity": "sha512-X4FOpUCvZuo42MdB1zAZ/wdX4N0lLcWDozf2KYFVDgtLv8Lx+f31LOYLP2/FcwTzsPi64bS/VwKqklI4RBletg==",
       "requires": {
         "spdx-compare": "^1.0.0",
-        "spdx-expression-parse": "^3.0.0",
         "spdx-ranges": "^2.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -17,8 +17,10 @@
     "run-parallel": "^1.1.9",
     "semver": "^5.6.0",
     "simple-concat": "^1.0.0",
+    "spdx-expression-parse": "^3.0.0",
     "spdx-expression-validate": "^2.0.0",
-    "spdx-satisfies": "^5.0.0"
+    "spdx-osi": "^3.0.0",
+    "spdx-whitelisted": "^1.0.0"
   },
   "bin": "./licensee",
   "files": [

--- a/tests/apache-2.0-mit-allowed/.licensee.json
+++ b/tests/apache-2.0-mit-allowed/.licensee.json
@@ -1,4 +1,9 @@
 {
-  "license": "(Apache-2.0 OR MIT)",
-  "whitelist": {}
+  "licenses": {
+    "spdx": [
+      "Apache-2.0",
+      "MIT"
+    ]
+  },
+  "packages": {}
 }

--- a/tests/blue-oak-fail/.licensee.json
+++ b/tests/blue-oak-fail/.licensee.json
@@ -1,4 +1,6 @@
 {
-  "blueOak": "bronze",
-  "whitelist": {}
+  "licenses": {
+    "blueOak": "bronze"
+  },
+  "packages": {}
 }

--- a/tests/blue-oak-pass/.licensee.json
+++ b/tests/blue-oak-pass/.licensee.json
@@ -1,4 +1,6 @@
 {
-  "blueOak": "bronze",
-  "whitelist": {}
+  "licenses": {
+    "blueOak": "bronze"
+  },
+  "packages": {}
 }

--- a/tests/ignored-author/.licensee.json
+++ b/tests/ignored-author/.licensee.json
@@ -1,6 +1,10 @@
 {
-  "license": "Apache-2.0",
-  "whitelist": {},
+  "licenses": {
+    "spdx": [
+      "Apache-2.0"
+    ]
+  },
+  "packages": {},
   "ignore": [
     {
       "author": "kyle"

--- a/tests/ignored-prefix/.licensee.json
+++ b/tests/ignored-prefix/.licensee.json
@@ -1,6 +1,10 @@
 {
-  "license": "Apache-2.0",
-  "whitelist": {},
+  "licenses": {
+    "spdx": [
+      "Apache-2.0"
+    ]
+  },
+  "packages": {},
   "ignore": [
     {
       "prefix": "doc"

--- a/tests/ignored-scope/.licensee.json
+++ b/tests/ignored-scope/.licensee.json
@@ -1,6 +1,10 @@
 {
-  "license": "Apache-2.0",
-  "whitelist": {},
+  "licenses": {
+    "spdx": [
+      "Apache-2.0"
+    ]
+  },
+  "packages": {},
   "ignore": [
     {
       "scope": "kemitchell"

--- a/tests/licenses-array-with-corrections/.licensee.json
+++ b/tests/licenses-array-with-corrections/.licensee.json
@@ -1,4 +1,8 @@
 {
-  "license": "MIT",
-  "whitelist": {}
+  "licenses": {
+    "spdx": [
+      "MIT"
+    ]
+  },
+  "packages": {}
 }

--- a/tests/mit-not-allowed/.licensee.json
+++ b/tests/mit-not-allowed/.licensee.json
@@ -1,4 +1,8 @@
 {
-  "license": "Apache-2.0",
-  "whitelist": {}
+  "licenses": {
+    "spdx": [
+      "Apache-2.0"
+    ]
+  },
+  "packages": {}
 }

--- a/tests/no-dependencies/.licensee.json
+++ b/tests/no-dependencies/.licensee.json
@@ -1,4 +1,8 @@
 {
-  "license": "MIT",
-  "whitelist": {}
+  "licenses": {
+    "spdx": [
+      "MIT"
+    ]
+  },
+  "packages": {}
 }

--- a/tests/no-whitelist/.licensee.json
+++ b/tests/no-whitelist/.licensee.json
@@ -1,3 +1,7 @@
 {
-  "license": "MIT"
+  "licenses": {
+    "spdx": [
+      "MIT"
+    ]
+  }
 }

--- a/tests/optimist-with-corrections-in-dotfile/.licensee.json
+++ b/tests/optimist-with-corrections-in-dotfile/.licensee.json
@@ -1,5 +1,9 @@
 {
-  "license": "MIT",
-  "whitelist": {},
+  "licenses": {
+    "spdx": [
+      "MIT"
+    ]
+  },
+  "packages": {},
   "corrections": true
 }

--- a/tests/optimist-with-corrections/.licensee.json
+++ b/tests/optimist-with-corrections/.licensee.json
@@ -1,4 +1,8 @@
 {
-  "license": "MIT",
-  "whitelist": {}
+  "licenses": {
+    "spdx": [
+      "MIT"
+    ]
+  },
+  "packages": {}
 }

--- a/tests/optimist-without-corrections/.licensee.json
+++ b/tests/optimist-without-corrections/.licensee.json
@@ -1,4 +1,8 @@
 {
-  "license": "MIT",
-  "whitelist": {}
+  "licenses": {
+    "spdx": [
+      "MIT"
+    ]
+  },
+  "packages": {}
 }

--- a/tests/osi-pass/.licensee.json
+++ b/tests/osi-pass/.licensee.json
@@ -1,0 +1,6 @@
+{
+  "licenses": {
+    "osi": true
+  },
+  "packages": {}
+}

--- a/tests/osi-pass/package.json
+++ b/tests/osi-pass/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "blue-oak-fail",
+  "dependencies": {
+    "gpl-2.0-licensed": "1.0.0"
+  },
+  "private": true
+}

--- a/tests/osi-pass/test.js
+++ b/tests/osi-pass/test.js
@@ -1,0 +1,5 @@
+var tap = require('tap')
+
+var results = require('../run')([], __dirname)
+
+tap.equal(results.status, 0)

--- a/tests/out-of-whitelisted-range/.licensee.json
+++ b/tests/out-of-whitelisted-range/.licensee.json
@@ -1,6 +1,10 @@
 {
-  "license": "Apache-2.0",
-  "whitelist": {
+  "licenses": {
+    "spdx": [
+      "Apache-2.0"
+    ]
+  },
+  "packages": {
     "mit-licensed": ">2.0.0"
   }
 }

--- a/tests/production-only/.licensee.json
+++ b/tests/production-only/.licensee.json
@@ -1,4 +1,8 @@
 {
-  "license": "MIT",
-  "whitelist": {}
+  "licenses": {
+    "spdx": [
+      "MIT"
+    ]
+  },
+  "packages": {}
 }

--- a/tests/unlicensed-subdependency/.licensee.json
+++ b/tests/unlicensed-subdependency/.licensee.json
@@ -1,4 +1,8 @@
 {
-  "license": "Apache-2.0",
-  "whitelist": {}
+  "licenses": {
+    "spdx": [
+      "Apache-2.0"
+    ]
+  },
+  "packages": {}
 }

--- a/tests/whitelisted/.licensee.json
+++ b/tests/whitelisted/.licensee.json
@@ -1,6 +1,10 @@
 {
-  "license": "Apache-2.0",
-  "whitelist": {
+  "licenses": {
+    "spdx": [
+      "Apache-2.0"
+    ]
+  },
+  "packages": {
     "mit-licensed": "1.0.0"
   }
 }


### PR DESCRIPTION
This PR works the license-whitelist functionality of `licensee` around `spdx-whitelisted`, a fork of `spdx-satisfies` that takes a new, promising approach.

Using `spdx-whitelisted` made it much simpler to implement more flexible license whitelisting. Configuration is now additive. Users can configure specific SPDX IDs, Blue Oak ratings, and an OSI flag to add licenses to the whitelist.

I am going to go ahead and merge this, since it's objectively better than what we have now, and addresses a few common requests, including #44. Will go out as v7.0.0, a semver-major bump.