### PR TITLE
standard@12.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ language: "node_js"
 node_js: [ "4", "5", "6", "7", "8", "9", "10", "11", "node" ]
 script:
   - "npm run test"
-  - "npm run style"
+  - 'if [ "$TRAVIS_NODE_VERSION" = "node" ]; then npm run style ; fi'
   - "npm run licenses"
 sudo: false

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ var simpleConcat = require('simple-concat')
 var spawn = require('child_process').spawn
 var spdxWhitelisted = require('spdx-whitelisted')
 
-function licensee (configuration, path, callback) {
+function licensee    (configuration, path, callback) {
   if (!validConfiguration(configuration)) {
     return callback(new Error('Invalid configuration'))
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4104,9 +4104,9 @@
       "dev": true
     },
     "object-keys": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.0.tgz",
-      "integrity": "sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "dev": true
     },
     "once": {
@@ -4376,9 +4376,9 @@
       "dev": true
     },
     "react-is": {
-      "version": "16.8.4",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.4.tgz",
-      "integrity": "sha512-PVadd+WaUDOAciICm/J1waJaSvgq+4rHE/K70j0PFqKhkTBsPv/82UGQJNXAngz1fOQLLxI6z1sEDmJDQhCTAA==",
+      "version": "16.8.6",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
+      "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
       "dev": true
     },
     "read-package-json": {


### PR DESCRIPTION
This PR allows us to upgrade to `standard` 12 for linting while still testing on old versions of Node.js that don't support the ES6 language features standard uses.

Basically, configure Travis CI to run `standard` only on the latest version of Node.js.