### PR TITLE
Catch error event from spawned npm process

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,6 +85,9 @@ function licensee (configuration, path, callback) {
       if (error) outputError = error
       else json = buffer
     })
+    child.once('error', function (error) {
+      outputError = error;
+    })
     child.once('close', function (code) {
       if (code !== 0) {
         done(new Error('npm exited with status ' + code))


### PR DESCRIPTION
Avoids node terminating with an unhandled 'error' event.