### PR TITLE
Ensure descriptive error is thrown when `packages` is missing

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ function licensee (configuration, path, callback) {
     }, [])
   if (
     configuration.licenses.length === 0 &&
-    Object.keys(configuration.packages).length === 0
+    (!configuration.packages || Object.keys(configuration.packages).length === 0)
   ) {
     callback(new Error('No licenses or packages whitelisted.'))
   } else {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "version": "7.0.3",
   "author": "Kyle E. Mitchell <kyle@kemitchell.com> (https://kemitchell.com/)",
   "contributors": [
-    "Jakob Krigovsky <jakob@krigovsky.com>"
+    "Jakob Krigovsky <jakob@krigovsky.com>",
+    "Brett Zamir <brett@brett-zamir.name>"
   ],
   "dependencies": {
     "@blueoak/list": "^1.0.2",


### PR DESCRIPTION
This was throwing "Cannot convert undefined or null to object" when `licenses` was empty and `packages` was missing (incidentally, I'd also like an option to be able to avoid this throwing code entirely, in order to get the raw meta-data without any approvals if you are amenable to such an option).