### PR TITLE
`filterPackages` callback option

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,12 @@ function licensee (configuration, path, callback) {
       // the dependency graph.
       readFilesystemTree(function (error, packages) {
         if (error) callback(error)
-        else withTrees(packages, false)
+        else {
+          if (configuration.filterPackages) {
+            packages = configuration.filterPackages(packages)
+          }
+          withTrees(packages, false)
+        }
       })
     }
   }


### PR DESCRIPTION
- In programmatic licensee, allow `filterPackages` callback to filter which packages have their children processed

This fixes #53 .

Rather than adding the complexity of directly supporting filtering for specific packages and their children, this adds a simple callback option by which the user can do so. It is an intermediate solution for @kemitchell 's helpful [suggestion](https://github.com/jslicense/licensee.js/issues/53#issuecomment-506604783). It avoids the user having to run `readFilesystemTree` separately on their own.

(In case anyone was wondering why I did not express as `packages = packages.filter(configuration.filterPackages)`, this per-item filtering would not be sufficient, as the filtering needed for determining dependencies is not linear; that is why the callback receives and returns a whole `packages` array: `packages = configuration.filterPackages(packages)`.)