### PR TITLE
Harmonize package-tree analysis with and without `--production`

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,11 +91,11 @@ function licensee (configuration, path, callback) {
       outputError = error
     })
     child.once('close', function (code) {
-      if (code !== 0) {
-        done(new Error('npm exited with status ' + code))
-      } else if (outputError) {
+      if (outputError) {
         done(outputError)
       } else {
+        if (code !== 0) console.error('Warning: npm exited with status ' + code)
+
         parseJSON(json, function (error, graph) {
           if (error) return done(error)
           if (!has(graph, 'dependencies')) {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "author": "Kyle E. Mitchell <kyle@kemitchell.com> (https://kemitchell.com/)",
   "contributors": [
     "Jakob Krigovsky <jakob@krigovsky.com>",
-    "Brett Zamir <brett@brett-zamir.name>"
+    "Brett Zamir <brett@brett-zamir.name>",
+    "Andrew Monks <a@monks.co>"
   ],
   "dependencies": {
     "@blueoak/list": "^1.0.2",

--- a/tests/with-npm-errors-in-production/.licensee.json
+++ b/tests/with-npm-errors-in-production/.licensee.json
@@ -1,0 +1,8 @@
+{
+  "licenses": {
+    "spdx": [
+      "MIT"
+    ]
+  },
+  "packages": {}
+}

--- a/tests/with-npm-errors-in-production/package.json
+++ b/tests/with-npm-errors-in-production/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "with-npm-errors-in-production",
+  "dependencies": {
+    "with-invalid-dependency": "^1.0.0"
+  },
+  "private": true
+}

--- a/tests/with-npm-errors-in-production/test.js
+++ b/tests/with-npm-errors-in-production/test.js
@@ -1,0 +1,10 @@
+var tap = require('tap')
+
+var results = require('../run')(['--production'], __dirname)
+
+tap.equal(results.status, 0)
+
+tap.equal(
+  results.stderr.indexOf('Warning: npm exited with status 1') !== -1,
+  true
+)


### PR DESCRIPTION
In #48, @nzacca and @kemitchell discussed the possibility of ignoring
peer dependency errors.

@kemitchell said,

> @nzacca ideally, I think licensee would succeed if it can do its job,
> and fail only if it can't, independent of whether other tools succeed
> or fail.

When `npm ls` encounters a peer-dependency violation or other error, it
does three things:

- log the error to stderr
- exit with a non-zero code
- log the result normally to stdout

WHAT WAS CHANGED:

This commit adds a flag, `--ignore-npm-errors` that makes licensee
proceed normally with the logged result, even if npm ls exits with a
non-zero code.

RISK:

I'm suspect this could produce operational errors down the line, if
there are cases where `npm ls` _does not_ log a result to stdout.