### PR TITLE
- Enhancement: Add config to be able to disable `npm ls` error aborting

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,7 +91,7 @@ function licensee (configuration, path, callback) {
       outputError = error
     })
     child.once('close', function (code) {
-      if (code !== 0) {
+      if (!configuration.disableLsErrorAborting && code !== 0) {
         done(new Error('npm exited with status ' + code))
       } else if (outputError) {
         done(outputError)

--- a/licensee
+++ b/licensee
@@ -20,6 +20,7 @@ var USAGE = [
   '  --osi                   Permit licenses approved by the Open Source Initiative.',
   '  --packages LIST         Permit comma-delimited name@range.',
   '  --errors-only           Only show NOT APPROVED packages.',
+  '  --disable-ls-error-aborting  Disables aborting upon `npm ls` errors (as may occur due to missing peerDeps)',
   '  --production            Do not check devDependencies.',
   '  --ndjson                Print newline-delimited JSON objects.',
   '  --quiet                 Quiet mode, only exit(0/1).',
@@ -117,6 +118,7 @@ if (options['--init']) {
 function checkDependencies () {
   configuration.productionOnly = options['--production']
   configuration.corrections = configuration.corrections || options['--corrections']
+  configuration.disableLsErrorAborting = options['--disable-ls-error-aborting']
   require('./')(configuration, cwd, function (error, dependencies) {
     if (error) {
       die(error.message + '\n')


### PR DESCRIPTION
Hi,

Have been enjoying using licensee.js within my license-badger program.

I ran into an issue just now though in that I get an exit code from the process which runs `npm ls`. I happen to know that the error can be safely ignored (a stated peer dependency is missing, but I know its absence to be safe), so I'd like to proceed (and if I skip the aborting, it goes on to check the licenses well as needed).

So this PR offers to disable such error exit codes from causing an abort. (I didn't re-indent the commands, as I figured there could be some desire to change the option name, assuming there was openness to adding the option.)