### PR TITLE
Add test case for symlinked node_modules with ignore

### DIFF
--- a/tests/symlinked-node-modules/.licensee.json
+++ b/tests/symlinked-node-modules/.licensee.json
@@ -1,0 +1,13 @@
+{
+  "licenses": {
+    "spdx": [
+      "Apache-2.0"
+    ]
+  },
+  "packages": {},
+  "ignore": [
+    {
+      "prefix": "mit-"
+    }
+  ]
+}

--- a/tests/symlinked-node-modules/node_modules/mit-licensed/index.js
+++ b/tests/symlinked-node-modules/node_modules/mit-licensed/index.js
@@ -1,0 +1,1 @@
+throw new Error('Do not require mit-licensed. It is just for testing license metadata.')

--- a/tests/symlinked-node-modules/node_modules/mit-licensed/package.json
+++ b/tests/symlinked-node-modules/node_modules/mit-licensed/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "mit-licensed",
+  "version": "1.0.0",
+  "description": "an empty package that is MIT-licensed",
+  "author": "Kyle E. Mitchell <kyle@kemitchell.com> (https://kemitchell.com/)",
+  "repository": "jslicense/mit-licensed.js",
+  "license": "MIT"
+}

--- a/tests/symlinked-node-modules/package-lock.json
+++ b/tests/symlinked-node-modules/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "allowed",
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "mit-licensed": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mit-licensed/-/mit-licensed-1.0.0.tgz",
+      "integrity": "sha1-/YBXPYPQBMezBoFz2z6MRB13A/k="
+    }
+  }
+}

--- a/tests/symlinked-node-modules/package.json
+++ b/tests/symlinked-node-modules/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "allowed",
+  "dependencies": {
+    "mit-licensed": "1.0.0"
+  },
+  "private": true
+}

--- a/tests/symlinked-node-modules/test.js
+++ b/tests/symlinked-node-modules/test.js
@@ -1,0 +1,5 @@
+var tap = require('tap')
+
+var results = require('../run')([], __dirname)
+
+tap.equal(results.status, 0)


### PR DESCRIPTION
Hoping to add a test case that will help us resolve some of the issues explored in https://github.com/jslicense/licensee.js/issues/70