### PR TITLE
Sort issues by package name

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,6 +101,11 @@ function findIssues (configuration, dependencies) {
       results.push(result)
     }
   })
+
+  results.sort(function (a, b) {
+    return a.name.localeCompare(b.name)
+  })
+
   return results
 }
 


### PR DESCRIPTION
Fixes a flaky test:

```
​ FAIL ​ tests/unlicensed-subdependency/test.js
 ✖ should be equal

  tests/unlicensed-subdependency/test.js
   5 | tap.equal(results.status, 1)
   6 |
>  7 | tap.equal(
     | ----^
   8 |   results.stdout.trim(),
   9 |   [
  10 |     'mit-licensed-depends-on-not-licensed@1.0.1',

  --- expected
  +++ actual
  @@ -1,15 +1,15 @@
  -mit-licensed-depends-on-not-licensed@1.0.1
  +not-licensed@1.0.0
     NOT APPROVED
  -  Terms: MIT
  -  Repository: jslicense/mit-licensed-depends-on-not-licensed.js
  +  Terms: Invalid license metadata
  +  Repository: jslicense/not-licensed.js
     Homepage: None listed
     Author: Kyle E. Mitchell <kyle@kemitchell.com> (https://kemitchell.com/)
     Contributors: None listed

  -not-licensed@1.0.0
  +mit-licensed-depends-on-not-licensed@1.0.1
     NOT APPROVED
  -  Terms: Invalid license metadata
  -  Repository: jslicense/not-licensed.js
  +  Terms: MIT
  +  Repository: jslicense/mit-licensed-depends-on-not-licensed.js
     Homepage: None listed
     Author: Kyle E. Mitchell <kyle@kemitchell.com> (https://kemitchell.com/)
     Contributors: None listed

  test: tests/unlicensed-subdependency/test.js
  stack: |
    Object.<anonymous> (tests/unlicensed-subdependency/test.js:7:5)
    Module.replacementCompile (node_modules/append-transform/index.js:60:13)
    Object.<anonymous> (node_modules/append-transform/index.js:64:4)

​ FAIL ​ tests/unlicensed-subdependency/test.js 1 failed of 2 16.992ms
 ✖ should be equal

  🌈 SUMMARY RESULTS 🌈

​ FAIL ​ tests/unlicensed-subdependency/test.js 1 failed of 2 16.992ms
 ✖ should be equal
```