### PR TITLE
Remove fs-access, use fs.access

### DIFF
--- a/licensee
+++ b/licensee
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-var access = require('fs-access')
 var docopt = require('docopt')
 var fs = require('fs')
 var has = require('has')
@@ -87,7 +86,7 @@ if (options['--init']) {
   }
   checkDependencies()
 } else {
-  access(configurationPath, function (error) {
+  fs.access(configurationPath, fs.constants.R_OK, function (error) {
     if (error) {
       die(
         [

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "@npmcli/arborist": "^6.1.2",
     "correct-license-metadata": "^1.4.0",
     "docopt": "^0.6.2",
-    "fs-access": "^2.0.0",
     "has": "^1.0.3",
     "npm-license-corrections": "^1.6.2",
     "semver": "^7.3.8",


### PR DESCRIPTION
Closes #66
Relates to #42

---

Remove the no-longer-necessary dependency on [fs-access](https://www.npmjs.com/package/fs-access) and use the [built-in fs module's access function](https://nodejs.org/docs/latest-v18.x/api/fs.html#fsaccesspath-mode-callback) instead.

I explicitly set the [access mode](https://nodejs.org/docs/latest-v18.x/api/fs.html#file-access-constants) to `R_OK` as the access check is performed in preparation for reading the file (and `F_OK` only checks whether the file is visible to the current user).

A note on the fs-access deprecation warning discussion: regardless of whether not it's a problem or which package should be responsible for addressing it, the facts are that:
1. fs-access won't receive any updates so using the built-in fs module is preferable, and
2. with [the currently supported Node.js version](https://github.com/jslicense/licensee.js/blob/9abd28fde91b5343a9b9322f6e5cb9547093febc/.github/workflows/ci.yml#L8) there's no need to use fs-access.
