### PR TITLE
[Breaking] update `@npmcli/arborist`; drop node < 14.17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,20 +1,13 @@
 name: CI
-on: [push]
+
+on: [pull_request, push]
+
+permissions:
+  contents: read
+
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node: ['12', '13', '14', '15', '16', '17', '18']
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: ${{ matrix.node }}
-          check-latest: true
-      - run: npm install
-      - run: npm test
-        env:
-          CI: true
-      - run: npm run lint
-      - run: npm run licenses
+  tests:
+    uses: ljharb/actions/.github/workflows/node-majors.yml@main
+    with:
+      range: '>= 14.17'
+      command: 'npm run tests-only && npm run licenses'

--- a/.github/workflows/pretest.yml
+++ b/.github/workflows/pretest.yml
@@ -1,0 +1,7 @@
+name: 'Tests: pretest/posttest'
+
+on: [pull_request, push]
+
+jobs:
+  tests:
+    uses: ljharb/actions/.github/workflows/pretest.yml@main

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "dependencies": {
     "@blueoak/list": "^9.0.0",
-    "@npmcli/arborist": "^5.6.3",
+    "@npmcli/arborist": "^6.1.2",
     "correct-license-metadata": "^1.4.0",
     "docopt": "^0.6.2",
     "fs-access": "^2.0.0",
@@ -43,6 +43,6 @@
     "test": "tap --no-check-coverage tests/unit.test.js tests/**/test.js"
   },
   "engines": {
-    "node": ">= 12.22"
+    "node": ">= 14.17"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "licensee"
   ],
   "devDependencies": {
+    "aud": "^2.0.1",
     "rimraf": "^3.0.2",
     "run-parallel": "^1.2.0",
     "spawn-sync": "^2.0.0",
@@ -40,7 +41,10 @@
   "scripts": {
     "licenses": "./licensee --errors-only",
     "lint": "standard index.js licensee test/**/test.js",
-    "test": "tap --no-check-coverage tests/unit.test.js tests/**/test.js"
+    "pretest": "npm run lint",
+    "tests-only": "tap --no-check-coverage tests/unit.test.js tests/**/test.js",
+    "test": "npm run tests-only",
+    "posttest": "aud --production"
   },
   "engines": {
     "node": ">= 14.17"


### PR DESCRIPTION
This will necessitate a major bump, but that seems fine.

The tests commit also makes a dynamic matrix, and closes #80.