### PR TITLE
Check for misspelled blueOak categories

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,13 @@ function validConfiguration (configuration) {
     isObject(configuration) &&
     has(configuration, 'licenses') &&
     isObject(configuration.licenses) &&
-    has(configuration, 'packages')
+    (!has(configuration.licenses, 'blueOak') ||
+      (
+        blueOakList.some(({ name }) =>
+          name.toLowerCase() === configuration.licenses.blueOak.toLowerCase()
+        )
+      )) &&
+    (has(configuration, 'packages')
       ? (
         // Validate `packages` property.
         isObject(configuration.packages) &&
@@ -64,7 +70,7 @@ function validConfiguration (configuration) {
           .every(function (key) {
             return isString(configuration.packages[key])
           })
-      ) : true
+      ) : true)
   )
 }
 

--- a/tests/blue-oak-misspelled/package.json
+++ b/tests/blue-oak-misspelled/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "blue-oak-misspelled",
+  "private": true
+}

--- a/tests/blue-oak-misspelled/test.js
+++ b/tests/blue-oak-misspelled/test.js
@@ -1,0 +1,5 @@
+var tap = require('tap')
+
+var results = require('../run')(['--blueoak=foobar'], __dirname)
+
+tap.equal(results.status, 1)


### PR DESCRIPTION
Closes #46

Adds a new check to the [`validConfiguration` function](https://github.com/jslicense/licensee.js/blob/99206bb43686c25e2889fd3c1769bdc8d4f98bea/index.js#L54-L70) that validates the provided blueOak string is a valid blueOak category. Also added a test for this case.