### PR TITLE
[Deps] update `@npmcli/arborist`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,5 +9,5 @@ jobs:
   tests:
     uses: ljharb/actions/.github/workflows/node-majors.yml@main
     with:
-      range: '>= 14.17'
+      range: '^16.14.0 || >=18.0.0'
       command: 'npm run tests-only && npm run licenses'

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "dependencies": {
     "@blueoak/list": "^9.0.0",
-    "@npmcli/arborist": "^6.1.2",
+    "@npmcli/arborist": "^7.2.0",
     "correct-license-metadata": "^1.4.0",
     "docopt": "^0.6.2",
     "has": "^1.0.3",
@@ -46,6 +46,6 @@
     "posttest": "aud --production"
   },
   "engines": {
-    "node": ">= 14.17"
+    "node": "^16.14.0 || >=18.0.0"
   }
 }


### PR DESCRIPTION
Update the dependency `@npmcli/arborist` from v6 to v7 in order to transitively upgrade dependencies such that `@npmcli/move-file` is removed from the (runtime) dependency tree (this follows [the recent release of `node-gyp` v10.0.0](https://github.com/nodejs/node-gyp/releases/tag/v10.0.0)). The motivation for this is that `@npmcli/move-file` has been deprecated because "This functionality has been moved to `@npmcli/fs`" for a while.

The breaking change from v6 to v7 is only that support for Node.js <=16.13 has been dropped. The implication is that that this change needs require a major version bump for `licensee` as well, since we [currently support >=14.17](https://github.com/jslicense/licensee.js/blob/d44aa11e7fe4154b0eae160c98278801d12f0fa5/package.json#L49). This new minimum Node.js version has been included here as well, based on the `engines.node` value for `@npmcli/arborist`. - See also #85.

The effect can be seen from within this repository as follows, before:

    $ npm i --omit dev
    npm WARN deprecated @npmcli/move-file@2.0.1: This functionality has been moved to @npmcli/fs

    added 263 packages, and audited 264 packages in 2s

    [...]

    $ npm ls --omit dev @npmcli/move-file
    licensee@10.0.0 /path/to/licensee
    └─┬ @npmcli/arborist@6.5.0
      └─┬ @npmcli/run-script@6.0.2
        └─┬ node-gyp@9.4.1
          └─┬ make-fetch-happen@10.2.1
            └─┬ cacache@16.1.3
              └── @npmcli/move-file@2.0.1

after:

    $ npm i --omit dev

    added 213 packages, and audited 214 packages in 2s

    [...]

    $ npm ls --omit dev @npmcli/move-file
    licensee@10.0.0 /path/to/licensee
    └── (empty)

    $ npm ls --omit dev cacache          
    licensee@10.0.0 /path/to/licensee
    └─┬ @npmcli/arborist@7.2.0
      ├─┬ @npmcli/metavuln-calculator@7.0.0
      │ └── cacache@18.0.0 deduped
      ├── cacache@18.0.0
      ├─┬ npm-registry-fetch@16.1.0
      │ └─┬ make-fetch-happen@13.0.0
      │   └── cacache@18.0.0 deduped
      └─┬ pacote@17.0.4
        └── cacache@18.0.0 deduped