### PR TITLE
Remove engines property from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,5 @@
     "tests-only": "tap --no-check-coverage tests/unit.test.js tests/**/test.js",
     "test": "npm run tests-only",
     "posttest": "aud --production"
-  },
-  "engines": {
-    "node": ">= 14.17"
   }
 }


### PR DESCRIPTION
See https://github.com/jslicense/licensee.js/pull/90#issuecomment-1784162651

Per [npm's package.json doc](https://docs.npmjs.com/cli/v6/configuring-npm/package-json#engines), at most setting `engines` gets us a warning on install.  The `engineStrict` property, which I don't think this package ever set, has been deprecated.

My general thinking on version support so far has been roughly:

- Checking licenses on long-dormant and "legacy" projects remains important.

- Many of those projects are locked to old Node.js versions.

- This is a relatively simple package, without need for many new language or core-library features, anyway.

- That said, we want to reuse, not reinvent, npm's ways of interpreting and analyzing `node_modules` directories.

- npm has its own preferences and constraints for Node.js version support, which we're going to inherit.

Upshot: CI across LTS versions so we can catch and revert new syntax, core APIs, or dependency versions that needlessly sacrifice support for projects on old LTS versions.

I don't like the idea of having to twiddle `engines` for every release.  And I'm not aware of any tools for analyzing our full production dep tree and calculating a composite supported `engines` range.  In practice, we're just having users do that when they run `npm install` on whatever `node` and `npm` they have.

However, in practice, I suspect most projects adopting `licensee` from scratch will be on later Node.js versions, and get away with just installing the latest `licensee`.  Those diving into old projects will likely have the `package.json` from days of yore, specifying an old `licensee` version that worked with whatever Node.js they were using at the time.  So long as we and all our dep authors make major version bumps for engine breaks, that should be fine.  Alternatively, we could ship `npm-shrinkwrap.json`, but that makes perpetual bump chores, and we've done fine without it so far.
