### PR TITLE
Prepare Version 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,4 +10,4 @@ jobs:
     uses: ljharb/actions/.github/workflows/node-majors.yml@main
     with:
       range: '>= 14.17'
-      command: 'npm run tests-only && npm run licenses'
+      command: 'npm run engines && npm run tests-only && npm run licenses'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,5 +9,5 @@ jobs:
   tests:
     uses: ljharb/actions/.github/workflows/node-majors.yml@main
     with:
-      range: '>= 14.17'
+      range: '^18.12 || ^20.9 || >= 22.7'
       command: 'npm run engines && npm run tests-only && npm run licenses'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,4 +10,4 @@ jobs:
     uses: ljharb/actions/.github/workflows/node-majors.yml@main
     with:
       range: '^18.12 || ^20.9 || >= 22.7'
-      command: 'npm run engines && npm run tests-only && npm run licenses'
+      command: 'npm run tests-only && npm run licenses'

--- a/.licensee.json
+++ b/.licensee.json
@@ -12,6 +12,7 @@
     "doctrine": "1.5.0",
     "esutils": "2.0.2",
     "json-schema": "0.2.3",
+    "jsonp": "0.2.1",
     "wordwrap": "0.0.2",
     "longest": "1.0.1",
     "repeat-element": "1.1.2"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   ],
   "devDependencies": {
     "aud": "^2.0.4",
+    "ls-engines": "^0.9.3",
     "rimraf": "^3.0.2",
     "run-parallel": "^1.2.0",
     "spawn-sync": "^2.0.0",
@@ -38,6 +39,7 @@
   "license": "Apache-2.0",
   "repository": "jslicense/licensee.js",
   "scripts": {
+    "engines": "ls-engines --check",
     "licenses": "./licensee --errors-only",
     "lint": "standard index.js licensee tests/**/*.js",
     "pretest": "npm run lint",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "license": "Apache-2.0",
   "repository": "jslicense/licensee.js",
   "scripts": {
-    "engines": "ls-engines --check",
+    "engines": "ls-engines --current",
     "licenses": "./licensee --errors-only",
     "lint": "standard index.js licensee tests/**/*.js",
     "pretest": "npm run lint",

--- a/package.json
+++ b/package.json
@@ -39,10 +39,10 @@
   "license": "Apache-2.0",
   "repository": "jslicense/licensee.js",
   "scripts": {
-    "engines": "ls-engines --current",
     "licenses": "./licensee --errors-only",
     "lint": "standard index.js licensee tests/**/*.js",
     "pretest": "npm run lint",
+    "postlint": "ls-engines --current",
     "tests-only": "tap --no-check-coverage tests/unit.test.js tests/**/test.js",
     "test": "npm run tests-only",
     "posttest": "aud --production"

--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
     "posttest": "aud --production"
   },
   "engines": {
-    "node": ">= 14.17"
+    "node": "^18.12 || ^20.9 || >= 22.7"
   }
 }


### PR DESCRIPTION
@ljharb, I have got a bit lost in all your modular Actions CI configuration.  Could I ask you to go in and correct my adding `ls-engines` to CI, or confirm that I managed to do it right?

I see there's an "engines" job that comes from all your configuration.  But I also see that's running `npx ls-engines --production false`.  We rather want to check production deps, ignoring dev deps and peer deps, on behalf of users.
