### PR TITLE
Update `@npmcli/arborist`

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "dependencies": {
     "@blueoak/list": "^15.0.0",
-    "@npmcli/arborist": "^6.5.0",
+    "@npmcli/arborist": "^7.2.1",
     "correct-license-metadata": "^1.4.0",
     "docopt": "^0.6.2",
     "hasown": "^2.0.0",


### PR DESCRIPTION
This is a new version of #90 following the engines update in #96. Now, the upgrade of `@npmcli/arborist` from v6 to v7 is no longer a breaking change for licensee. I had to recreate the PR because I had deleted my fork of this project.

---

Update the dependency `@npmcli/arborist` from v6 to v7 in order to transitively upgrade or remove deprecated dependencies. For example, the dependency `@npmcli/move-file` is deprecated and dropped by `@npmcli/arborist` v7. Similarly, the dependency `glob` is deprecated at v7 and v8 (both were previously in the dependency tree) and has been upgrade to v10.

The exact version I picked is the first v7 release that occurred after the release of the release of v6.5.0, which hopefully means any feature of v6.5.0 used by this project is also present in the selected minimum v7 release.

The effect can be seen from within this repository as follows, before (on `main` at d746a5b5b1e32cd8ed940ecbba7796be52d7119b):

    $ npm install --omit dev
    npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
    npm warn deprecated @npmcli/move-file@2.0.1: This functionality has been moved to @npmcli/fs
    npm warn deprecated read-package-json@6.0.4: This package is no longer supported. Please use @npmcli/package-json instead.
    npm warn deprecated npmlog@7.0.1: This package is no longer supported.
    npm warn deprecated npmlog@6.0.2: This package is no longer supported.
    npm warn deprecated rimraf@3.0.2: Rimraf versions prior to v4 are no longer supported
    npm warn deprecated are-we-there-yet@4.0.2: This package is no longer supported.
    npm warn deprecated are-we-there-yet@3.0.1: This package is no longer supported.
    npm warn deprecated glob@8.1.0: Glob versions prior to v9 are no longer supported
    npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
    npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
    npm warn deprecated gauge@5.0.2: This package is no longer supported.
    npm warn deprecated gauge@4.0.4: This package is no longer supported.

    added 268 packages, and audited 269 packages in 4s

    [...]

after (this PR):

    $ npm install --omit dev

    added 187 packages, and audited 188 packages in 3s

    [...]