### PR TITLE
Dont require corrections for licensee

### DIFF
--- a/licensee
+++ b/licensee
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-var docopt = require('docopt')
+var docopt = require('@quenk/docopt')
 var fs = require('fs')
 var has = require('hasown')
 var path = require('path')

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@blueoak/list": "^15.0.0",
     "@npmcli/arborist": "^7.2.1",
     "correct-license-metadata": "^1.4.0",
-    "docopt": "^0.6.2",
+    "@quenk/docopt": "^1.0.1",
     "hasown": "^2.0.0",
     "npm-license-corrections": "^1.6.2",
     "semver": "^7.6.0",


### PR DESCRIPTION
User story: I would like to add licensee as a dev-dep, and run licensee without `--corrections`, and without having to manually add a license exception.